### PR TITLE
rename go module

### DIFF
--- a/example/cmd/handlers.go
+++ b/example/cmd/handlers.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"go-protobuf-mutator/example/service"
+
+	"github.com/yandex-cloud/go-protobuf-mutator/example/service"
 
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	pb "go-protobuf-mutator/testdata"
+	pb "github.com/yandex-cloud/go-protobuf-mutator/testdata"
 )
 
 func ParseProtoMessage(data []byte) ([]byte, handler, proto.Message, error) {

--- a/example/cmd/handlers_test.go
+++ b/example/cmd/handlers_test.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	pb "go-protobuf-mutator/testdata"
+	pb "github.com/yandex-cloud/go-protobuf-mutator/testdata"
 )
 
 func TestParseProtoMessage(t *testing.T) {

--- a/example/cmd/libfuzzer.go
+++ b/example/cmd/libfuzzer.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	mutator "go-protobuf-mutator"
+	mutator "github.com/yandex-cloud/go-protobuf-mutator"
 )
 
 // #include <stdint.h>

--- a/example/service/fuzzing.go
+++ b/example/service/fuzzing.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 
-	pb "go-protobuf-mutator/testdata"
+	pb "github.com/yandex-cloud/go-protobuf-mutator/testdata"
 
 	"google.golang.org/protobuf/proto"
 )

--- a/example/service/grpc.go
+++ b/example/service/grpc.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 
-	pb "go-protobuf-mutator/testdata"
+	pb "github.com/yandex-cloud/go-protobuf-mutator/testdata"
 )
 
 type service struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-protobuf-mutator
+module github.com/yandex-cloud/go-protobuf-mutator
 
 go 1.22
 

--- a/mutator_test.go
+++ b/mutator_test.go
@@ -1,9 +1,10 @@
 package mutator
 
 import (
-	testdata "go-protobuf-mutator/testdata"
 	"testing"
 	"time"
+
+	testdata "github.com/yandex-cloud/go-protobuf-mutator/testdata"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"


### PR DESCRIPTION
Rename module to `github.com/yandex-cloud/go-protobuf-mutator`