### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/yandex-cloud/go-protobuf-mutator/security/code-scanning/1](https://github.com/yandex-cloud/go-protobuf-mutator/security/code-scanning/1)

To fix this problem, you should add a `permissions` block with the least privilege required for your workflow. For read-only workflows that do not need to push changes or perform other write actions, set `permissions: contents: read` at the root level of the workflow (just below the `name:`), so all jobs will inherit this minimal token scope by default. This will restrict the `GITHUB_TOKEN` to only have read access to repository contents during workflow execution. No imports or other definitions are needed; this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
